### PR TITLE
Make notebook for the Introduction to Python

### DIFF
--- a/Co-Creation0_IntroToPython.ipynb
+++ b/Co-Creation0_IntroToPython.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "apparent-christianity",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Following discussion among the Co-Creation project staff, was decided to
introduce students to coding in Python with a Jupyter notebook.  This
commit establishes that notebook and is to be filled with a tutorial.

As @ynyrharris's first commit, this commit is basically a test.